### PR TITLE
Fix

### DIFF
--- a/Stats.cs
+++ b/Stats.cs
@@ -87,10 +87,10 @@ namespace StatKeeper
 
         public ulong SteamID { get; set; } = 0;
         public DateTime LastUpdated { get; set; } = DateTime.Now;
-        public DateTime Created { get; private set; } = DateTime.Now;
+        public DateTime Created { get; set; } = DateTime.Now;
 
-        public SerializableDictionary<string, int> Kills { get; private set; } = new SerializableDictionary<string, int>();
-        public SerializableDictionary<string, int> Deaths { get; private set; } = new SerializableDictionary<string, int>();
+        public SerializableDictionary<string, int> Kills { get; set; } = new SerializableDictionary<string, int>();
+        public SerializableDictionary<string, int> Deaths { get; set; } = new SerializableDictionary<string, int>();
 
         public double KDRatio { get; set; } = 0;
         public int TotalKills { get; set; } = 0;


### PR DESCRIPTION
Fix
[8/3/2019 10:16:44 AM] [Error] InvalidOperationException: Cannot deserialize type 'StatKeeper.Stats' because it contains property 'Created' which has no public setter. - System.Xml.Serialization.TypeScope.GetSettableMembers (System.Xml.Serialization.StructMapping mapping, System.Collections.ArrayList list) (at <03e950671d964403ab67ff751c460757>:0)
System.Xml.Serialization.TypeScope.GetSettableMembers (System.Xml.Serialization.StructMapping structMapping) (at <03e950671d964403ab67ff751c460757>:0)
System.Xml.Serialization.TypeScope.GetSettableMembers (System.Xml.Serialization.StructMapping mapping, System.Collections.Generic.Dictionary`2[TKey,TValue] memberInfos) (at <03e950671d964403ab67ff751c460757>:0)
System.Xml.Serialization.XmlSerializationReaderILGen.WriteLiteralStructMethod (System.Xml.Serialization.StructMapping structMapping) (at <03e950671d964403ab67ff751c460757>:0)
System.Xml.Serialization.XmlSerializationReaderILGen.WriteStructMethod (System.Xml.Serialization.StructMapping structMapping) (at <03e950671d964403ab67ff751c460757>:0)
System.Xml.Serialization.XmlSerializationReaderILGen.GenerateMethod (System.Xml.Serialization.TypeMapping mapping) (at <03e950671d964403ab67ff751c460757>:0)
System.Xml.Serialization.XmlSerializationILGen.GenerateReferencedMethods () (at <03e950671d964403ab67ff751c460757>:0)
System.Xml.Serialization.XmlSerializationReaderILGen.GenerateEnd (System.String[] methods, System.Xml.Serialization.XmlMapping[] xmlMappings, System.Type[] types) (at <03e950671d964403ab67ff751c460757>:0)
System.Xml.Serialization.TempAssembly.GenerateRefEmitAssembly (System.Xml.Serialization.XmlMapping[] xmlMappings, System.Type[] types, System.String defaultNamespace, System.Security.Policy.Evidence evidence) (at <03e950671d964403ab67ff751c460757>:0)
System.Xml.Serialization.TempAssembly..ctor (System.Xml.Serialization.XmlMapping[] xmlMappings, System.Type[] types, System.String defaultNamespace, System.String location, System.Security.Policy.Evidence evidence) (at <03e950671d964403ab67ff751c460757>:0)
System.Xml.Serialization.XmlSerializer.GenerateTempAssembly (System.Xml.Serialization.XmlMapping xmlMapping, System.Type type, System.String defaultNamespace, System.String location, System.Security.Policy.Evidence evidence) (at <03e950671d964403ab67ff751c460757>:0)
System.Xml.Serialization.XmlSerializer..ctor (System.Type type, System.Xml.Serialization.XmlAttributeOverrides overrides, System.Type[] extraTypes, System.Xml.Serialization.XmlRootAttribute root, System.String defaultNamespace, System.String location, System.Security.Policy.Evidence evidence) (at <03e950671d964403ab67ff751c460757>:0)
System.Xml.Serialization.XmlSerializer..ctor (System.Type type, System.Xml.Serialization.XmlAttributeOverrides overrides, System.Type[] extraTypes, System.Xml.Serialization.XmlRootAttribute root, System.String defaultNamespace, System.String location) (at <03e950671d964403ab67ff751c460757>:0)
System.Xml.Serialization.XmlSerializer..ctor (System.Type type, System.Type[] extraTypes) (at <03e950671d964403ab67ff751c460757>:0)
Rocket.Core.Assets.XMLFileAsset`1[T]..ctor (System.String file, System.Type[] extraTypes, StatKeeper.Stats defaultInstance) (at <466fa14d466749559a64a11ae8acbc60>:0)
StatKeeper.StatsPlayerComponent.Start () (at <a5bb1ddfdc4846a996b6903aeac44316>:0)